### PR TITLE
[002] 단기 예보 Entity 저장 Rest API 생성

### DIFF
--- a/application/sync-application/src/main/java/org/example/controller/SyncController.java
+++ b/application/sync-application/src/main/java/org/example/controller/SyncController.java
@@ -1,0 +1,26 @@
+package org.example.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.dto.OpenApiRequestDto;
+import org.example.entity.Weather;
+import org.example.service.SyncService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class SyncController {
+    private final SyncService syncService;
+
+    @PostMapping("/sync")
+    public ResponseEntity<List<Weather>> saveWeather(@RequestBody @Valid OpenApiRequestDto requestDto) {
+        return ResponseEntity.ok(syncService.saveWeather(requestDto));
+    }
+}

--- a/application/sync-application/src/main/java/org/example/service/SyncService.java
+++ b/application/sync-application/src/main/java/org/example/service/SyncService.java
@@ -1,0 +1,58 @@
+package org.example.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.api.WeatherOpenApi;
+import org.example.dto.OpenApiRequestDto;
+import org.example.dto.OpenApiResponseDto;
+import org.example.entity.Weather;
+import org.example.repository.WeatherRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SyncService {
+    private final WeatherOpenApi weatherOpenApi;
+    private final WeatherRepository weatherRepository;
+
+    @Transactional
+    public List<Weather> saveWeather(OpenApiRequestDto requestDto) {
+        List<OpenApiResponseDto> responseDtoList = weatherOpenApi.useOpenApi(requestDto);
+
+        // 중복된 데이터 우선 제거
+        deleteOldData(responseDtoList);
+        List<Weather> weatherList = new ArrayList<>();
+
+        for (OpenApiResponseDto dto : responseDtoList) {
+
+            Weather weather = Weather.builder()
+                    .baseDate(dto.getBaseDate())
+                    .baseTime(dto.getBaseTime())
+                    .category(dto.getCategory())
+                    .forecastDate(dto.getFcstDate())
+                    .forecastTime(dto.getFcstTime())
+                    .forecastValue(dto.getFcstValue())
+                    .nx(dto.getNx())
+                    .ny(dto.getNy())
+                    .build();
+
+            weatherRepository.save(weather);
+            weatherList.add(weather);
+        }
+        return weatherList;
+    }
+    private void deleteOldData(List<OpenApiResponseDto> dtoList) {
+        for (OpenApiResponseDto dto : dtoList) {
+            if (existData(dto)) {
+                weatherRepository.deleteAllByForecastDateAndForecastTime(dto.getFcstDate(), dto.getFcstTime());
+            }
+        }
+    }
+
+    private boolean existData(OpenApiResponseDto dto) {
+        return weatherRepository.existsByForecastDateAndForecastTime(dto.getFcstDate(), dto.getFcstTime());
+    }
+}


### PR DESCRIPTION
### Sync-application
- `/api/sycn` Http POST 호출
- 중복 조회했던 값이 있을 경우 해당 날짜 값 전체 제거
    - 제거 시 N 개의 Delete 쿼리 대신 Delete ALL 을 이용해 하나의 쿼리로 개선